### PR TITLE
Correction of relative path in setup.py

### DIFF
--- a/matminer/setup.py
+++ b/matminer/setup.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     setup(
         name="matminer",
         use_scm_version={
-            "root": ".",
+            "root": "..",
             "relative_to": __file__,
             "local_scheme": local_version,
         },


### PR DESCRIPTION
Hi, I noticed that the relative path in setup.py was wrong when I tried to install matminer. It now worked to install matminer for me, hopefully this helps others too. 